### PR TITLE
Android 9+ support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ captures/
 .idea/gradle.xml
 .idea/dictionaries
 .idea/libraries
+.idea/caches
+.idea/codeStyles
 
 # Keystore files
 *.jks

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,26 +5,37 @@
     <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
     <option name="myNullables">
       <value>
-        <list size="4">
+        <list size="10">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
           <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
           <item index="3" class="java.lang.String" itemvalue="android.support.annotation.Nullable" />
+          <item index="4" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
+          <item index="5" class="java.lang.String" itemvalue="androidx.annotation.Nullable" />
+          <item index="6" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNullable" />
+          <item index="7" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.Nullable" />
+          <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
+          <item index="9" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
         </list>
       </value>
     </option>
     <option name="myNotNulls">
       <value>
-        <list size="4">
+        <list size="9">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
           <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
           <item index="3" class="java.lang.String" itemvalue="android.support.annotation.NonNull" />
+          <item index="4" class="java.lang.String" itemvalue="androidx.annotation.NonNull" />
+          <item index="5" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNonNull" />
+          <item index="6" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.NonNull" />
+          <item index="7" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
+          <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
         </list>
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8 (1)" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,10 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/OverlayHelper.iml" filepath="$PROJECT_DIR$/OverlayHelper.iml" />
-      <module fileurl="file://$PROJECT_DIR$/OverlayHelper.iml" filepath="$PROJECT_DIR$/OverlayHelper.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
-      <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
-      <module fileurl="file://$PROJECT_DIR$/lib/lib.iml" filepath="$PROJECT_DIR$/lib/lib.iml" />
       <module fileurl="file://$PROJECT_DIR$/lib/lib.iml" filepath="$PROJECT_DIR$/lib/lib.iml" />
     </modules>
   </component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,7 +3,10 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/OverlayHelper.iml" filepath="$PROJECT_DIR$/OverlayHelper.iml" />
+      <module fileurl="file://$PROJECT_DIR$/OverlayHelper.iml" filepath="$PROJECT_DIR$/OverlayHelper.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
+      <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
+      <module fileurl="file://$PROJECT_DIR$/lib/lib.iml" filepath="$PROJECT_DIR$/lib/lib.iml" />
       <module fileurl="file://$PROJECT_DIR$/lib/lib.iml" filepath="$PROJECT_DIR$/lib/lib.iml" />
     </modules>
   </component>

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ Add the following dependencies to your app's `build.gradle`:
 * For Gradle < 4.0
     ```groovy
     dependencies {
-        compile "com.github.adriangl:overlayhelper:1.0.0"
+        compile "com.github.adriangl:overlayhelper:1.1.0"
     }
     ```
 
 * For Gradle 4.0+
     ```groovy
     dependencies {
-        implementation "com.github.adriangl:overlayhelper:1.0.0"
+        implementation "com.github.adriangl:overlayhelper:1.1.0"
     }
     ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.1"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -21,8 +21,8 @@ android {
 dependencies {
     implementation project(":lib")
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "com.android.support:appcompat-v7:28.0.0"
+    implementation 'androidx.appcompat:appcompat:1.0.2'
     testImplementation "junit:junit:4.12"
-    androidTestImplementation "com.android.support.test:runner:1.0.2"
-    androidTestImplementation "com.android.support.test.espresso:espresso-core:3.0.2"
+    androidTestImplementation 'androidx.test:runner:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: "com.android.application"
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         applicationId "com.adriangl.overlayhelperexample"
         minSdkVersion 19
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
-        versionName "1.0"
+        versionName "1.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
@@ -21,8 +21,8 @@ android {
 dependencies {
     implementation project(":lib")
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "com.android.support:appcompat-v7:27.0.2"
+    implementation "com.android.support:appcompat-v7:28.0.0"
     testImplementation "junit:junit:4.12"
-    androidTestImplementation "com.android.support.test:runner:1.0.1"
-    androidTestImplementation "com.android.support.test.espresso:espresso-core:3.0.1"
+    androidTestImplementation "com.android.support.test:runner:1.0.2"
+    androidTestImplementation "com.android.support.test.espresso:espresso-core:3.0.2"
 }

--- a/app/src/androidTest/java/com/adriangl/overlayhelper/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/com/adriangl/overlayhelper/ExampleInstrumentedTest.java
@@ -1,8 +1,8 @@
 package com.adriangl.overlayhelper;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/app/src/main/java/com/adriangl/overlayhelperexample/MainActivity.java
+++ b/app/src/main/java/com/adriangl/overlayhelperexample/MainActivity.java
@@ -2,7 +2,7 @@ package com.adriangl.overlayhelperexample;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:3.0.1"
+        classpath 'com.android.tools.build:gradle:3.4.0-rc02'
         classpath "com.github.dcendents:android-maven-gradle-plugin:2.0"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 25 16:20:43 CET 2018
+#Thu Mar 21 11:09:33 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -22,7 +22,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-
 }
 
 dependencies {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -4,13 +4,13 @@ apply plugin: 'com.github.dcendents.android-maven'
 group = "com.github.adriangl"
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
-        versionName "1.0"
+        versionName "1.1"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
@@ -27,10 +27,10 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "com.android.support:support-annotations:27.0.2"
+    implementation "com.android.support:support-annotations:28.0.0"
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.1'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }
 
 // build a jar with source files

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -42,8 +42,8 @@ task sourcesJar(type: Jar) {
 task javadoc(type: Javadoc) {
     failOnError false
     source = android.sourceSets.main.java.sourceFiles
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    classpath += configurations.compile
+    configurations.implementation.setCanBeResolved(true)
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator)) + configurations.implementation
 }
 
 // build a jar with javadoc

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -12,7 +12,7 @@ android {
         versionCode 1
         versionName "1.1"
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
     }
 
@@ -27,10 +27,10 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "com.android.support:support-annotations:28.0.0"
+    implementation 'androidx.annotation:annotation:1.0.2'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test:runner:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
 }
 
 // build a jar with source files

--- a/lib/src/androidTest/java/com/adriangl/overlayhelper/ExampleInstrumentedTest.java
+++ b/lib/src/androidTest/java/com/adriangl/overlayhelper/ExampleInstrumentedTest.java
@@ -1,8 +1,8 @@
 package com.adriangl.overlayhelper;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/lib/src/main/java/com/adriangl/overlayhelper/OverlayDelegate.java
+++ b/lib/src/main/java/com/adriangl/overlayhelper/OverlayDelegate.java
@@ -4,8 +4,8 @@ import android.app.AppOpsManager;
 import android.content.Context;
 import android.os.Build;
 import android.provider.Settings;
-import android.support.annotation.RequiresApi;
-import android.support.annotation.RequiresPermission;
+import androidx.annotation.RequiresApi;
+import androidx.annotation.RequiresPermission;
 
 /**
  * Interface used to implement custom overlay checking behaviour depending on device version.

--- a/lib/src/main/java/com/adriangl/overlayhelper/OverlayDelegate.java
+++ b/lib/src/main/java/com/adriangl/overlayhelper/OverlayDelegate.java
@@ -131,4 +131,28 @@ interface OverlayDelegate {
             return canDrawOverlays;
         }
     }
+
+    /**
+     * Implementation of {@link OverlayDelegate} for devices with API level >= 28.
+     */
+    @RequiresApi(api = Build.VERSION_CODES.P)
+    class PieOverlayDelegate implements OverlayDelegate {
+        private final Context context;
+
+        PieOverlayDelegate(Context context) {
+            this.context = context;
+        }
+
+        @Override public void startWatching() {
+            // No-op
+        }
+
+        @Override public void stopWatching() {
+            // No-op
+        }
+
+        @Override public boolean canDrawOverlays() {
+            return Settings.canDrawOverlays(context);
+        }
+    }
 }

--- a/lib/src/main/java/com/adriangl/overlayhelper/OverlayHelper.java
+++ b/lib/src/main/java/com/adriangl/overlayhelper/OverlayHelper.java
@@ -54,8 +54,11 @@ public class OverlayHelper {
         this.context = ctx.getApplicationContext();
         this.overlayPermissionChangedListener = listener;
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            // API 26+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            // API 28+: The checks return to API 23-like behaviour
+            this.overlayDelegate = new OverlayDelegate.PieOverlayDelegate(context);
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            // API 26+: Fucks up checks, so we need to store the values of the alert window setting in the delegate
             this.overlayDelegate = new OverlayDelegate.OreoOverlayDelegate(context);
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             // API 23+: check if the user has explicitly enabled overlays

--- a/lib/src/main/java/com/adriangl/overlayhelper/OverlayHelper.java
+++ b/lib/src/main/java/com/adriangl/overlayhelper/OverlayHelper.java
@@ -11,13 +11,14 @@ import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
 import android.provider.Settings;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.RequiresPermission;
-import android.support.annotation.StringRes;
 
 import java.util.Arrays;
 import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresPermission;
+import androidx.annotation.StringRes;
 
 /**
  * Helper class that takes care of querying and requesting permissions for drawing over other apps.


### PR DESCRIPTION
Add proper support for Android 9+ versions in the lib.
Now there is no need to watch the setting to get if overlays are enabled.

Also migrate to AndroidX and update libraries and plugins